### PR TITLE
Accept code "YT" for Yukon`

### DIFF
--- a/lib/rates.json
+++ b/lib/rates.json
@@ -83,5 +83,10 @@
     "province": "YK",
     "tax": "GST",
     "value": "0.05"
+  },
+  {
+    "province": "YT",
+    "tax": "GST",
+    "value": "0.05"
   }
 ]


### PR DESCRIPTION
Hello Mike,

Thank you for your library. The 'official' code for Yukon is 'YT', though 'YK' is commonly used. This pr adds "YT" option.

Tisha out in Calgary